### PR TITLE
runs used GPUs, just using set GPU=true in prm file

### DIFF
--- a/accuracyBenchmarks/Al12Mg17/dftfe/study1/parameterFile_kpoint4x4x4.prm
+++ b/accuracyBenchmarks/Al12Mg17/dftfe/study1/parameterFile_kpoint4x4x4.prm
@@ -1,5 +1,5 @@
 set SOLVER MODE=GS
-
+set USE GPU=true
 subsection Geometry
   set NATOMS=58
   set NATOM TYPES=2

--- a/accuracyBenchmarks/Al12Mg17/dftfe/study2/parameterFile.prm
+++ b/accuracyBenchmarks/Al12Mg17/dftfe/study2/parameterFile.prm
@@ -1,6 +1,6 @@
 set SOLVER MODE=GEOOPT
 set RESTART=false
-
+set USE GPU=true
 subsection Geometry
   set NATOMS=58
   set NATOM TYPES=2


### PR DESCRIPTION
In the benchmarks, I used GPUs but didn't pushed the .prm file with set USE GPU=true flag. So updating the .prm files.